### PR TITLE
Add timestamp font scaling based on resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 build/
 dist/
 *.spec
+*.pyc

--- a/dencam/recorder.py
+++ b/dencam/recorder.py
@@ -53,7 +53,7 @@ class BaseRecorder(ABC):
         self.camera = PiCamera(framerate=FRAME_RATE)
         self.camera.rotation = CAMERA_ROTATION
         self.camera.resolution = CAMERA_RESOLUTION
-        self.camera.annotate_text_size = 80
+        self.camera.annotate_text_size = (1/20) * CAMERA_RESOLUTION[1]
         self.camera.annotate_foreground = picamera.color.Color('white')
         self.camera.annotate_background = picamera.color.Color('black')
 


### PR DESCRIPTION
* Move from hardcoded timestamp font to scaled timestamp font based on camera resolution.
* Ignore .pyc files