### PR TITLE
20 airplane mode

### DIFF
--- a/dencam.py
+++ b/dencam.py
@@ -15,13 +15,13 @@ panels.
 import logging
 import argparse
 import time
-
 import yaml
 
 from dencam import logs
 from dencam.buttons import ButtonHandler
 from dencam.recorder import Recorder
 from dencam.gui import Controller, State
+from dencam.airplane_mode import AirplaneMode
 
 parser = argparse.ArgumentParser()
 parser.add_argument('config_file',
@@ -53,8 +53,10 @@ def main():
     try:
         recorder = Recorder(configs)
         state = State(NUM_STATES)
+        Airplanemode = AirplaneMode(configs)
         button_handler = ButtonHandler(recorder,
                                        state,
+                                       Airplanemode,
                                        lambda: flags['stop_buttons_flag'])
         button_handler.setDaemon(True)
         button_handler.start()

--- a/dencam/airplane_mode.py
+++ b/dencam/airplane_mode.py
@@ -1,0 +1,24 @@
+import os
+
+
+class AirplaneMode:
+
+    def __init__(self, configs):
+        APM = configs['AIRPLANEMODE']
+        if APM:
+            self.AP_Mode_ON()
+        else:
+            self.AP_Mode_OFF()
+
+    def AP_Mode_ON(self):
+        os.system("rfkill block wlan")
+        os.system("rfkill block bluetooth")
+        self.Enabled = True
+
+    def AP_Mode_OFF(self):
+        os.system("rfkill unblock wlan")
+        os.system("rfkill unblock bluetooth")
+        self.Enabled = False
+
+    def get_Enabled(self):
+        return self.Enabled

--- a/dencam/buttons.py
+++ b/dencam/buttons.py
@@ -30,13 +30,13 @@ class ButtonHandler(Thread):
 
     """
 
-    def __init__(self, recorder, state, stop_flag):
+    def __init__(self, recorder, state, Airplanemode, stop_flag):
         super().__init__()
 
         self.recorder = recorder
         self.state = state
         self.stop_flag = stop_flag
-
+        self. Airplanemode = Airplanemode
         self.latch_screen_button = False
         self.latch_record_button = False
         self.latch_preview_button = False
@@ -90,7 +90,11 @@ class ButtonHandler(Thread):
                     self.recorder.start_preview()
                 elif self.state.value == 0:
                     self.recorder.stop_preview()
-
+                #elif self.state.value == 1:
+                    #if self.Airplanemode.get_Enabled():
+                        #self.Airplanemode.AP_Mode_OFF()
+                    #else:
+                        #self.Airplanemode.AP_Mode_ON()
                 self._set_screen_brightness()
         else:
             self.latch_screen_button = False
@@ -103,7 +107,11 @@ class ButtonHandler(Thread):
                     self.recorder.toggle_recording()
                 elif self.state.value == 4:
                     self.recorder.toggle_zoom()
-
+                elif self.state.value == 1:
+                    if object.get_Enabled:
+                        self.AP_Mode_OFF
+                    else:
+                        self.AP_Mode_ON
                 self.latch_record_button = True
         else:
             self.latch_record_button = False

--- a/dencam/buttons.py
+++ b/dencam/buttons.py
@@ -90,11 +90,6 @@ class ButtonHandler(Thread):
                     self.recorder.start_preview()
                 elif self.state.value == 0:
                     self.recorder.stop_preview()
-                #elif self.state.value == 1:
-                    #if self.Airplanemode.get_Enabled():
-                        #self.Airplanemode.AP_Mode_OFF()
-                    #else:
-                        #self.Airplanemode.AP_Mode_ON()
                 self._set_screen_brightness()
         else:
             self.latch_screen_button = False
@@ -108,10 +103,10 @@ class ButtonHandler(Thread):
                 elif self.state.value == 4:
                     self.recorder.toggle_zoom()
                 elif self.state.value == 1:
-                    if object.get_Enabled:
-                        self.AP_Mode_OFF
+                    if self.Airplanemode.get_Enabled():
+                        self.Airplanemode.AP_Mode_OFF()
                     else:
-                        self.AP_Mode_ON
+                        self.Airplanemode.AP_Mode_ON()
                 self.latch_record_button = True
         else:
             self.latch_record_button = False

--- a/dencam/example_config.yaml
+++ b/dencam/example_config.yaml
@@ -17,3 +17,5 @@ FRAME_RATE: 25
 
 # 0, 90, 180, 270. have not checked whether 90 and 270 crop image or what
 CAMERA_ROTATION: 180 
+
+AIRPLANEMODE: False


### PR DESCRIPTION
Added Airplane mode feature using os.system to write to terminal rfkill commands to block and unblock wifi and bluetooth connections. 

Added yaml variable to be able to decide whether airplane mode is on/off on boot.

 Added a toggle feature to the networking page, using the second button, when pressed will enable or disable airplane mode(when enabling, the networking text disappears from the screen instantly, but when disabling it does take a few seconds to pop back up)

closes issue #20 