### PR TITLE
Fix page flash

### DIFF
--- a/dencam/gui.py
+++ b/dencam/gui.py
@@ -66,7 +66,7 @@ class BaseController(Thread):
 
             frame.grid(row=0, column=0, sticky='nsew')
 
-        self.show_frame('RecordingPage')
+        self.show_frame('NetworkPage')
 
     def show_frame(self, page_name):
         frame = self.frames[page_name]


### PR DESCRIPTION
On line 69, self.show_frame('RecordingPage'), caused the recording page to show briefly. Changed that and now it no longer flashes.
Resolves issue #44